### PR TITLE
Numbers in csv Writer

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -222,6 +222,10 @@ function _appendField(outArr, writer, field) {
         outArr.push('');
         return;
     }
+    if (field.length == undefined){
+       //deal with numbers
+       field = '' + field;
+    }
     for (var i = 0; i < field.length; i++) {
         if (field.charAt(i) === writer.quotechar || field.charAt(i) === writer.escapechar) {
             outArr.push(writer.escapechar);


### PR DESCRIPTION
Came across an issue when writing numbers to csv, data.length is undefined so it can't write out numbers. explicitly turn them into strings so that a number can be written
