### PR TITLE
Leniency for nested quotes

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -65,12 +65,13 @@ CsvReader.prototype.parse = function(data) {
                         break;
                     }
                     if (ps.quotedField) {
-                        // closing quote should be followed by separator
+                        // closing quote should be followed by separator unless the nested quotes option is set
                         var nextChar = data.charAt(i + 1);
-                        if (nextChar && nextChar != '\r' && nextChar != '\n' && nextChar !== this.separator) {
+                        if (nextChar && nextChar != '\r' && nextChar != '\n' && nextChar !== this.separator && this.nestedQuotes != true) {
                             throw new Error("separator expected after a closing quote; found " + nextChar);
+                        } else {
+                            ps.quotedField = false;
                         }
-                        ps.quotedField = false;
                     } else if (ps.openField === '') {
                         ps.quotedField = true;
                     }
@@ -256,6 +257,7 @@ function _setOptions(obj, options) {
     obj.commentchar = options.comment     || '';
     obj.columnNames = options.columnNames || [];
     obj.columnsFromHeader = options.columnsFromHeader || false;
+    obj.nestedQuotes = options.nestedQuotes || false;
 };
 
 function _checkVersionNumber() {


### PR DESCRIPTION
Some third-party CSV files such as the one from MalwareDomainList.com unfortunately contain nested, non-escaped quotes in some fields, resulting in an error being thrown and the termination of the file processing (and typically the node process). To accommodate this, it was necessary to add a nestedQuotes boolean option.  Tested on Natty with node v0.4.10 and npm 1.0.27
