### PR TITLE
Strip BOM to handle a file encoded as ucs2.

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -27,6 +27,11 @@ sys.inherits(CsvReader, events.EventEmitter);
 
 CsvReader.prototype.parse = function(data) {
     var ps = this.parsingStatus;
+    if (ps.openRecord.length == 0) {
+        if (data.charCodeAt(0) === 0xFEFF) {
+            data = data.slice(1);
+        }
+    }
     for (var i = 0; i < data.length; i++) {
         var c = data.charAt(i);
         switch (c) {


### PR DESCRIPTION
Current version of ya-csv has a problem while dealing with ucs encoded file, even set encoding option.
Please review this patch.

Thanks
