### PR TITLE
Make createCsvFileWriter()'s <options> param optional

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -309,6 +309,7 @@ function _appendField(outArr, writer, field) {
 };
 
 csv.createCsvFileWriter = function(path, options) {
+    options = options || {'flags': 'w'};
     var writeStream = fs.createWriteStream(path, {
         'flags': options.flags || 'w'
     });


### PR DESCRIPTION
Hey Pavel,

First off, thanks for ya-csv. It's a great library and saved me hours of work. I appreciate it!

This patch is to fix a "quirk" in the new version that makes the `options` param to `createCsvFileWriter()` required, when it seems it's meant to be optional.

It's not broken as-is, but you do have to pass in `{flags: 'w'}` for the `options` parameter or else it'll throw an error.

Let me know if that wasn't the intent.

Thanks!
