### PR TITLE
allow empty string options

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -326,11 +326,11 @@ csv.createCsvStreamWriter = function(writeStream, options) {
 
 function _setOptions(obj, options) {
     options = options || {};
-    obj.separator   = options.separator   || ',';
-    obj.quotechar   = options.quote       || '"';
-    obj.escapechar  = options.escape      || '"';
-    obj.commentchar = options.comment     || '';
-    obj.columnNames = options.columnNames || [];
-    obj.columnsFromHeader = options.columnsFromHeader || false;
-    obj.nestedQuotes = options.nestedQuotes || false;
+    obj.separator = (typeof options.separator !== 'undefined') ? options.separator : ',';
+    obj.quotechar = (typeof options.quote !== 'undefined') ? options.quote : '"';
+    obj.escapechar = (typeof options.escape !== 'undefined') ? options.escape : '"';
+    obj.commentchar = (typeof options.comment !== 'undefined') ? options.comment : '';
+    obj.columnNames = (typeof options.columnNames !== 'undefined') ? options.columnNames : [];
+    obj.columnsFromHeader = (typeof options.columnsFromHeader !== 'undefined') ? options.columnsFromHeader : false;
+    obj.nestedQuotes = (typeof options.nestedQuotes !== 'undefined') ? options.nestedQuotes : false;
 };

--- a/test/empty-quote.js
+++ b/test/empty-quote.js
@@ -1,0 +1,30 @@
+var csv = require('../lib/ya-csv'),
+    stream = require('stream'),
+    assert = require('assert');
+    
+// create a really simple writable stream
+var writeStream = new stream.Stream();
+writeStream.writable = true;
+writeStream.data = '';
+writeStream.write = function(data) {
+  // this csv writer doesn't allow commas since there is no
+  // quote or escape character. We're writing this for a really
+  // piss-poor csv implementation.
+  this.data += data.replace(/,/g, '');
+};
+writeStream.end = function() {
+  // nothing to do
+};
+
+// create csv writer with empty string options
+var csvWriter = csv.createCsvStreamWriter(writeStream, {
+  separator: ',', // must remove in writeStream.write()
+  quote: '',
+  escape: ''
+});
+
+var csvRecord = ['John Smith', 'Customer 999', 'United States'];
+csvWriter.writeRecord(csvRecord);
+
+var expected = "John Smith,Customer 999,United States\r\n";
+assert.strictEqual(writeStream.data, expected);

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
-var sys;
+var util;
 try {
-  sys    = require('util'); 
+  util    = require('util'); 
 } catch (e) {
-  util = require('util');
+  util = require('sys');
 }
 
 var csv    = require('../lib/ya-csv'),


### PR DESCRIPTION
This allows setting an option to an empty string. I needed this so I could write a csv file for a crappy csv-implementation that just used commas for the separator but didn't support quoting of the fields.
