### PR TITLE
Allow user's `columnNames` option to override first row (header) of CSV

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -216,7 +216,9 @@ CsvReader.prototype.setColumnNames = function(names) {
 CsvReader.prototype._addRecord = function() {
     var ps = this.parsingStatus;
     if (this.columnsFromHeader && ps.rows === 0) {
-        this.setColumnNames(ps.openRecord);
+        // user has passed columnNames through option
+        if (this.columnNames.length === 0)
+          this.setColumnNames(ps.openRecord);
     } else if (this.columnNames != null && this.columnNames.length > 0) {
         var objResult = {};
         for (var i = 0; i < this.columnNames.length; i++) {


### PR DESCRIPTION
This can replace the ugly headers in `ugly-header.csv`.

``` javascript
var reader = csv.createCsvFileReader(filepath, {
  columnsFromHeader: true,
  columnNames: ["_id", "name"]
});
```

`ugly-header.csv`

```
"LoginName","EnglishFullName"
"vadar", "Darth Vadar"
"luke", "Luke SkyWalker"
```
