### PR TITLE
Trim leading and trailing whitespaces in a field, per the CSV spec (such...

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -204,7 +204,7 @@ CsvReader.prototype._addCharacter = function(c) {
 
 CsvReader.prototype._addField = function() {
     var ps = this.parsingStatus;
-    ps.openRecord.push(ps.openField);
+    ps.openRecord.push(ps.openField.trim());
     ps.openField = '';
     ps.quotedField = false;
 };


### PR DESCRIPTION
... as it is)
