### PR TITLE
Emit parsing error instead of throwing.

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -128,7 +128,7 @@ CsvReader.prototype.parse = function(data) {
                         // closing quote should be followed by separator unless the nested quotes option is set
                         var nextChar = data.charAt(i + 1);
                         if (nextChar && nextChar != '\r' && nextChar != '\n' && nextChar !== this.separator && this.nestedQuotes != true) {
-                            throw new Error("separator expected after a closing quote; found " + nextChar);
+                            return this.emit('error', new Error("separator expected after a closing quote; found " + nextChar))
                         } else {
                             ps.quotedField = false;
                         }


### PR DESCRIPTION
This makes it possible to get errors in the `.on('error')` handler and `return` stops parsing (as `throw` was stopping parsing before).
