### PR TITLE
Allow CsvStreamWriter to handle null values.

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -282,9 +282,12 @@ function _writeArray(writer, arr) {
     var out = [];
     for (var i = 0; i < arr.length; i++) {
         if (i != 0) out.push(writer.separator);
-        out.push(writer.quotechar);
-        _appendField(out, writer, arr[i]);
-        out.push(writer.quotechar);
+        var value = arr[i];
+        if (typeof value !== "undefined" && value !== null) {
+          out.push(writer.quotechar);
+          _appendField(out, writer, value);
+          out.push(writer.quotechar);
+        }
     }
     out.push("\r\n");
     writer.writeStream.write(out.join(''), this.encoding);


### PR DESCRIPTION
Don't output "" when a field is empty. Most parsers interpret this as
a single double-quote character.
