### PR TITLE
Correctly emit errors thrown when we attempt to parse a line.

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -30,6 +30,7 @@ var csv = exports;
  */
 var CsvReader = csv.CsvReader = function(readStream, options) {
     var self = this;
+    var hasEnded = false;
     _setOptions(self, options);
 
     self.parsingStatus = {
@@ -42,7 +43,18 @@ var CsvReader = csv.CsvReader = function(readStream, options) {
     };
 
     if (readStream) {
-        readStream.addListener('data', this.parse.bind(this));
+        readStream.addListener('data', function (data) {
+            if (hasEnded) {
+                return;
+            }
+
+            try {
+                self.parse(data);
+            } catch (e) {
+                hasEnded = true;
+                self.emit('error', e);
+            }
+        });
         readStream.addListener('error', this.emit.bind(this, 'error'));
         readStream.addListener('end', this.end.bind(this));
 


### PR DESCRIPTION
We hit an issue using 0.9.2 with an error being thrown while parsing a line rather than being emitted as an event from the stream.

This change is intended to catch any parse errors and emit them as an error event - as written it maintains the invariant that once an error has been emitted no more data is processed.
