### PR TITLE
Add writer option to escape formulas

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -302,7 +302,7 @@ function _writeArray(writer, arr) {
         out.push(writer.quotechar);
     }
     out.push("\r\n");
-    writer.writeStream.write(out.join(''), this.encoding);
+    writer.writeStream.write(out.join(''), writer.encoding);
 };
 
 function _appendField(outArr, writer, field) {

--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -318,10 +318,15 @@ function _appendField(outArr, writer, field) {
     }
 
     for (var i = 0; i < field.length; i++) {
-        if (field.charAt(i) === writer.quotechar || field.charAt(i) === writer.escapechar) {
+        var nextChar = field.charAt(i);
+        if (nextChar === writer.quotechar || nextChar === writer.escapechar) {
             outArr.push(writer.escapechar);
+        } else if (writer.escapeFormulas && i === 0 && (nextChar === '=' || nextChar === '+' || nextChar === '-')) {
+            // If a field starts with =, +, or -, Excel etc will interpret it as a formula. Adding an apostrophe fixes this.
+            outArr.push('\'');
         }
-        outArr.push(field.charAt(i));
+
+        outArr.push(nextChar);
     }
 };
 
@@ -350,4 +355,5 @@ function _setOptions(obj, options) {
     obj.columnNames = (typeof options.columnNames !== 'undefined') ? options.columnNames : [];
     obj.columnsFromHeader = (typeof options.columnsFromHeader !== 'undefined') ? options.columnsFromHeader : false;
     obj.nestedQuotes = (typeof options.nestedQuotes !== 'undefined') ? options.nestedQuotes : false;
+    obj.escapeFormulas = (typeof options.escapeFormulas !== 'undefined') ? options.escapeFormulas : false;
 };


### PR DESCRIPTION
Currently, the CSV writer will output exactly what it is input. If the input starts with a formula trigger (+, =, or -) this will cause the formula to be executed in Excel/OpenOffice/LibreOffice/etc. When the spreadsheet data is generated from user input, this can be dangerous.

See [this OWASP page](https://www.owasp.org/index.php/CSV_Excel_Macro_Injection) about the security vulnerability. While some users may intentionally include formulas in their CSV files, there should be an option to escape them. This PR adds that option, escapeFormulas.
