### PR TITLE
Add a close() method to the CsvWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ upload_form.onPart = function(part) {
     });
     part.on('end', function() {
         reader.end()
-    }
+    })
 }
 ```
 

--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -301,6 +301,16 @@ CsvWriter.prototype.writeRecord = function(rec) {
     _writeArray(this, rec);
 };
 
+CsvWriter.prototype.close = function() {
+    if (this.writeStream.destroy) {
+        this.writeStream.destroy();
+    } else if (this.writeStream.end) {
+        this.writeStream.end();
+    } else if (this.writeStream.close) {
+        this.writeStream.close();
+    }
+};
+
 function _writeArray(writer, arr) {
     var out = [];
     for (var i = 0; i < arr.length; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,11 @@ var columns = 0;
 
 csvIn.addListener('end', function() {
     assert.strictEqual(expectedRows, lines, "Wrong number of records");
+    csvOut.close();
+});
+
+csvOut.addListener('close', function(){
+    console.log('Closed the writer');
 });
 
 csvIn.addListener('data', function(data) {


### PR DESCRIPTION
When using the `CsvWriter` in a non-stream fashion (e.g. iterating a list and writing records), often times it is necessary to ensure the underlying stream is closed (especially if you could be writing thousands of files). Of course, this can be handled outside of `ya-csv` by passing in your own writeStream and managing it yourself. Hence, this is not _necessary_ per se, but rather a nicety to the API.

Thanks!