### PR TITLE
Fix reader.pause() not stopping mid-chunk row emission (#41)

### DIFF
--- a/lib/ya-csv.js
+++ b/lib/ya-csv.js
@@ -31,6 +31,7 @@ var csv = exports;
 var CsvReader = csv.CsvReader = function(readStream, options) {
     var self = this;
     var hasEnded = false;
+    self.paused = false;
     _setOptions(self, options);
 
     self.parsingStatus = {
@@ -39,7 +40,8 @@ var CsvReader = csv.CsvReader = function(readStream, options) {
         openField:     '',
         lastChar:      '',
         quotedField:   false,
-        commentedLine: false
+        commentedLine: false,
+        pendingData:   null
     };
 
     if (readStream) {
@@ -60,22 +62,37 @@ var CsvReader = csv.CsvReader = function(readStream, options) {
 
 
         /**
-         * Pauses the readStream
+         * Pauses the readStream. Also stops parse() from emitting any
+         * further records out of data that has already been delivered but
+         * not yet fully parsed, since a single 'data' chunk from readStream
+         * can contain many CSV rows and readStream.pause() alone only
+         * prevents *future* chunks from arriving.
          * @method pause
          * @return {ReadStream} the readstream instance
          */
         self.pause = function(){
+            self.paused = true;
             readStream.pause();
             return self;
         };
 
         /**
-         * Resumes the readStream
+         * Resumes the readStream. First finishes parsing any data left
+         * over from before pause() cut a chunk short, then resumes
+         * readStream so further chunks can arrive.
          * @method resume
          * @return {ReadStream} the readstream instance
          */
         self.resume = function(){
-            readStream.resume();
+            self.paused = false;
+            var pending = self.parsingStatus.pendingData;
+            self.parsingStatus.pendingData = null;
+            if (pending) {
+                self.parse(pending);
+            }
+            if (!self.paused) {
+                readStream.resume();
+            }
             return self;
         }
 
@@ -188,6 +205,16 @@ CsvReader.prototype.parse = function(data) {
                 this._addCharacter(c);
         }
         ps.lastChar = c;
+
+        // pause() may have been called synchronously by a 'data' listener
+        // (e.g. after _addRecord() emitted a row above). Stop parsing this
+        // chunk right away and stash whatever's left so resume() can pick
+        // up where we left off, instead of racing through every remaining
+        // row already sitting in this chunk.
+        if (this.paused) {
+            ps.pendingData = data.slice(i + 1);
+            return;
+        }
     }
 };
 

--- a/test/pause.js
+++ b/test/pause.js
@@ -1,0 +1,52 @@
+// Regression test for issue #41: reader.pause() didn't stop the reader
+// from emitting rows that were already sitting in a 'data' chunk that had
+// more than one CSV row in it. readStream.pause() only prevents *future*
+// chunks from arriving; it does nothing about rows still queued up inside
+// the chunk parse() is already looping over.
+var csv    = require('../lib/ya-csv'),
+    events = require('events'),
+    util   = require('util'),
+    assert = require('assert');
+
+// A minimal fake readStream: just enough surface (addListener/pause/resume)
+// for CsvReader to work with, so we can control exactly when/how much data
+// arrives and observe whether pause() really took effect.
+function FakeStream() {
+    events.EventEmitter.call(this);
+}
+util.inherits(FakeStream, events.EventEmitter);
+FakeStream.prototype.setEncoding = function() {};
+FakeStream.prototype.pause = function() {
+    this.paused = true;
+};
+FakeStream.prototype.resume = function() {
+    this.paused = false;
+};
+
+var fakeStream = new FakeStream();
+var reader = csv.createCsvStreamReader(fakeStream, {});
+
+var rows = [];
+reader.addListener('data', function(row) {
+    rows.push(row);
+    if (rows.length === 1) {
+        reader.pause();
+    }
+});
+
+// A single chunk containing three complete rows, just like a real
+// readStream would deliver when a small file (or one buffered block of a
+// larger one) arrives in one piece.
+fakeStream.emit('data', 'a,b\r\nc,d\r\ne,f\r\n');
+
+assert.strictEqual(rows.length, 1,
+    'pause() should stop parsing before the remaining rows in the same chunk are emitted');
+assert.ok(fakeStream.paused, 'the underlying stream should also have been paused');
+
+reader.resume();
+
+assert.strictEqual(rows.length, 3,
+    'resume() should finish parsing the rows left over from the paused chunk');
+assert.deepEqual(rows, [['a', 'b'], ['c', 'd'], ['e', 'f']]);
+
+console.log('pause/resume test passed');


### PR DESCRIPTION
## Summary

Fixes #41.

`CsvReader.prototype.parse()` loops over an entire incoming `data` chunk synchronously, emitting a `data` event (one CSV row) each time it finishes a record. `reader.pause()` only called `readStream.pause()`, which prevents *future* chunks from arriving — but does nothing to stop `parse()` from continuing to race through every other row that's already sitting in the *current* chunk.

That means if a chunk happens to contain many rows (a small file delivered in one chunk, or just a large `highWaterMark`), calling `pause()` from inside a `'data'` listener had no visible effect until the whole chunk was fully parsed — exactly the symptom reported in #41 ("I expect this code to read only 1 line and than pause and it doesn't stop").

Reproduced independently with a 200,000-row file and a small `highWaterMark`: after calling `pause()` on the first row, over 1,900 more rows were emitted before the pause actually took hold.

## Fix

- `parse()` now checks a `paused` flag after processing each character. If it's set (because a `'data'` listener called `pause()` synchronously), it stops immediately and stashes the unconsumed remainder of the chunk on `parsingStatus.pendingData` instead of continuing through the rest of the buffer.
- `resume()` first finishes parsing that leftover chunk (which may itself get paused again if the caller calls `pause()` again while handling one of those rows), and only calls `readStream.resume()` once nothing is left pending and we're not paused again.

This is a minimal, backward-compatible change — `pause()`/`resume()` keep the same signatures and return value, and non-streaming use of `parse()` (with no `readStream`) is unaffected since `this.paused` is simply always `false` in that case.

## Test plan

- Added `test/pause.js`: drives a fake stream that delivers three CSV rows in a single `'data'` chunk, calls `reader.pause()` after the first row is emitted, and asserts no further rows are emitted until `reader.resume()` is called.
- Verified the new test fails on unpatched `master` (all 3 rows emitted immediately, `pause()` has no effect) and passes with the fix.
- Re-ran the 200k-row / small-`highWaterMark` manual repro above: row count now correctly freezes at 1 while paused, then resumes to completion after `resume()`.
- `test/index.js` and `test/empty-quote.js` have pre-existing failures on current `master` under Node 22 (unrelated `ERR_STREAM_DESTROYED` / escaping regression, also independently noted by PR #55) — confirmed identical failures before and after this change, so nothing here regresses them further.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QdVVTsVZjsr9a6cwUwkHJV)_